### PR TITLE
 Fix #13 and enhancements  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 # vendor/
 bin/
 *.snap
+
+# hola-proxy binary
+hola-proxy

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hola-proxy](https://snapcraft.io//hola-proxy/badge.svg)](https://snapcraft.io/hola-proxy)
 
-Standalone Hola proxy client. Just run it and it'll start plain HTTP proxy server forwarding traffic via Hola proxies of your choice. By default application listens port on 127.0.0.1:8080.
+Standalone Hola proxy client. Just run it and it'll start plain HTTP proxy server forwarding traffic via Hola proxies of your choice. By default application listens port on 127.0.0.1:8081.
 
 Application is capable to forward traffic via proxies in datacenters (flag `-proxy-type direct`, default) or via peer proxies on residental IPs (consumer ISP) in that country (flag `-proxy-type peer`).
 
@@ -54,7 +54,7 @@ Docker image is available as well. Here is an example for running proxy via DE a
 ```sh
 docker run -d \
     --security-opt no-new-privileges \
-    -p 127.0.0.1:8080:8080 \
+    -p 127.0.0.1:8081:8081 \
     --restart unless-stopped \
     --name hola-proxy \
     yarmak/hola-proxy -country de
@@ -148,7 +148,7 @@ zagent248.hola.org,165.22.65.3,22222,22223,digitalocean
 $ ~/go/bin/hola-proxy -h
 Usage of /home/user/go/bin/hola-proxy:
   -bind-address string
-    	HTTP proxy listen address (default "127.0.0.1:8080")
+    	HTTP proxy listen address (default "127.0.0.1:8081")
   -country string
     	desired proxy location (default "us")
   -limit uint

--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ dk - Denmark
 es - Spain
 fi - Finland
 fr - France
+gb - United Kingdom (Great Britain)
 gr - Greece
 hk - Hong Kong
+hr - Croatia
 hu - Hungary
 id - Indonesia
 ie - Ireland

--- a/README.md
+++ b/README.md
@@ -125,21 +125,21 @@ $ ~/go/bin/hola-proxy -country de
 Or run proxy on residental IP:
 
 ```
-$ ~/go/bin/hola-proxy -country de -proxy-type peer
+$ ~/go/bin/hola-proxy -country de -proxy-type lum
 ```
 
 Also it is possible to export proxy addresses and credentials:
 
 ```
 $ ~/go/bin/hola-proxy -country de -list-proxies -limit 3
-Login: user-uuid-f4c2c3a8657640048e7243a807867d52
-Password: e194c4f457e0
-Proxy-Authorization: basic dXNlci11dWlkLWY0YzJjM2E4NjU3NjQwMDQ4ZTcyNDNhODA3ODY3ZDUyOmUxOTRjNGY0NTdlMA==
+Login: user-uuid-0a67c797b3214cbdb432b089c4b801cd
+Password: cd123c465901
+Proxy-Authorization: basic dXNlci11dWlkLTBhNjdjNzk3YjMyMTRjYmRiNDMyYjA4OWM0YjgwMWNkOmNkMTIzYzQ2NTkwMQ==
 
-Host,IP address,Direct port,Peer port,Vendor
-zagent90.hola.org,185.72.246.203,22222,22223,nqhost
-zagent249.hola.org,165.22.80.107,22222,22223,digitalocean
-zagent248.hola.org,165.22.65.3,22222,22223,digitalocean
+host,ip_address,direct,peer,hola,trial,trial_peer,vendor
+zagent783.hola.org,165.22.22.6,22222,22223,22224,22225,22226,digitalocean
+zagent830.hola.org,104.248.24.64,22222,22223,22224,22225,22226,digitalocean
+zagent248.hola.org,165.22.65.3,22222,22223,22224,22225,22226,digitalocean
 ```
 
 ## Synopsis
@@ -158,14 +158,15 @@ Usage of /home/user/go/bin/hola-proxy:
   -list-proxies
     	output proxy list and exit
   -proxy-type string
-    	proxy type: direct or peer (default "direct")
+    	proxy type: direct or peer or lum (default "direct")
   -resolver string
     	DNS/DoH/DoT resolver to workaround Hola blocked hosts. See https://github.com/ameshkov/dnslookup/ for upstream DNS URL format. (default "https://cloudflare-dns.com/dns-query")
   -rotate duration
     	rotate user ID once per given period (default 1h0m0s)
   -timeout duration
     	timeout for network operations (default 10s)
+  -use-trial
+    	use trial ports instead of regular ports
   -verbosity int
     	logging verbosity (10 - debug, 20 - info, 30 - warning, 40 - error, 50 - critical) (default 20)
-
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hola-proxy](https://snapcraft.io//hola-proxy/badge.svg)](https://snapcraft.io/hola-proxy)
 
-Standalone Hola proxy client. Just run it and it'll start plain HTTP proxy server forwarding traffic via Hola proxies of your choice. By default application listens port on 127.0.0.1:8081.
+Standalone Hola proxy client. Just run it and it'll start plain HTTP proxy server forwarding traffic via Hola proxies of your choice. By default application listens port on 127.0.0.1:8080.
 
 Application is capable to forward traffic via proxies in datacenters (flag `-proxy-type direct`, default) or via peer proxies on residental IPs (consumer ISP) in that country (flag `-proxy-type peer`).
 
@@ -54,7 +54,7 @@ Docker image is available as well. Here is an example for running proxy via DE a
 ```sh
 docker run -d \
     --security-opt no-new-privileges \
-    -p 127.0.0.1:8081:8081 \
+    -p 127.0.0.1:8080:8080 \
     --restart unless-stopped \
     --name hola-proxy \
     yarmak/hola-proxy -country de
@@ -148,7 +148,7 @@ zagent248.hola.org,165.22.65.3,22222,22223,digitalocean
 $ ~/go/bin/hola-proxy -h
 Usage of /home/user/go/bin/hola-proxy:
   -bind-address string
-    	HTTP proxy listen address (default "127.0.0.1:8081")
+    	HTTP proxy listen address (default "127.0.0.1:8080")
   -country string
     	desired proxy location (default "us")
   -limit uint

--- a/credservice.go
+++ b/credservice.go
@@ -11,6 +11,7 @@ const API_CALL_ATTEMPTS = 3
 
 func CredService(interval, timeout time.Duration,
                  country string,
+                 proxytype string,
                  logger *CondLogger) (auth AuthProvider,
                                       tunnels *ZGetTunnelsResponse,
                                       err error) {
@@ -25,7 +26,7 @@ func CredService(interval, timeout time.Duration,
 
     for i := 0; i < API_CALL_ATTEMPTS ; i++ {
         ctx, _ := context.WithTimeout(context.Background(), timeout)
-        tunnels, user_uuid, err = Tunnels(ctx, country, DEFAULT_LIST_LIMIT)
+        tunnels, user_uuid, err = Tunnels(ctx, country, proxytype, DEFAULT_LIST_LIMIT)
         if err == nil {
             break
         }
@@ -49,7 +50,7 @@ func CredService(interval, timeout time.Duration,
             logger.Info("Rotating credentials...")
             for i := 0; i < API_CALL_ATTEMPTS ; i++ {
                 ctx, _ := context.WithTimeout(context.Background(), timeout)
-                tuns, user_uuid, err = Tunnels(ctx, country, DEFAULT_LIST_LIMIT)
+                tuns, user_uuid, err = Tunnels(ctx, country, proxytype, DEFAULT_LIST_LIMIT)
                 if err == nil {
                     break
                 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/AdguardTeam/dnsproxy v0.25.0
+	github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e
 	github.com/google/uuid v1.1.1
 	github.com/miekg/dns v1.1.29
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/ameshkov/dnscrypt v1.1.0/go.mod h1:ikduAxNLCTEfd1AaCgpIA5TgroIVQ8JY3V
 github.com/ameshkov/dnsstamps v1.0.1 h1:LhGvgWDzhNJh+kBQd/AfUlq1vfVe109huiXw4JhnPug=
 github.com/ameshkov/dnsstamps v1.0.1/go.mod h1:Ii3eUu73dx4Vw5O4wjzmT5+lkCwovjzaEZZ4gKyIH5A=
 github.com/beefsack/go-rate v0.0.0-20180408011153-efa7637bb9b6/go.mod h1:6YNgTHLutezwnBvyneBbwvB8C82y3dcoOj5EQJIdGXA=
+github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e h1:V9a67dfYqPLAvzk5hMQOXYJlZ4SLIXgyKIE+ZiHzgGQ=
+github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func parse_args() CLIArgs {
     flag.BoolVar(&args.list_countries, "list-countries", false, "list available countries and exit")
     flag.BoolVar(&args.list_proxies, "list-proxies", false, "output proxy list and exit")
     flag.UintVar(&args.limit, "limit", 3, "amount of proxies in retrieved list")
-    flag.StringVar(&args.bind_address, "bind-address", "127.0.0.1:8081", "HTTP proxy listen address")
+    flag.StringVar(&args.bind_address, "bind-address", "127.0.0.1:8080", "HTTP proxy listen address")
     flag.IntVar(&args.verbosity, "verbosity", 20, "logging verbosity " +
             "(10 - debug, 20 - info, 30 - warning, 40 - error, 50 - critical)")
     flag.DurationVar(&args.timeout, "timeout", 10 * time.Second, "timeout for network operations")


### PR DESCRIPTION


* Add `-use-trial` to use trial ports.
* Mention Hola and Trial ports in `-list-proxies`
* Add GB to `-list-countries` if UK is present. This is what extension does.
* Add `lum` proxy-type to use residential ips
* Change `peer` and `lum` behavior to also modify the country to `country_code`.peer and `country_code`.pool_lum_`country_code`._shared. This lets them work properly
* Above means that `list-proxies` behavior will change based on `-proxy-type` now(The port isn't the only thing that matters)

