### PR TITLE
Skip upstream agent resolve

### DIFF
--- a/holaapi.go
+++ b/holaapi.go
@@ -106,9 +106,9 @@ func (c *FallbackConfig) ShuffleAgents() {
 
 func (c *FallbackConfig) Clone() *FallbackConfig {
 	return &FallbackConfig{
-		Agents: append([]FallbackAgent(nil), c.Agents...),
+		Agents:    append([]FallbackAgent(nil), c.Agents...),
 		UpdatedAt: c.UpdatedAt,
-		TTL: c.TTL,
+		TTL:       c.TTL,
 	}
 }
 
@@ -338,7 +338,7 @@ func httpClientWithProxy(agent *FallbackAgent) *http.Client {
 		t.Proxy = http.ProxyURL(agent.ToProxy())
 		addr := net.JoinHostPort(agent.IP, fmt.Sprintf("%d", agent.Port))
 		t.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
-			return dialer.DialContext(ctx, "tcp4", addr)
+			return dialer.DialContext(ctx, "tcp", addr)
 		}
 	}
 	return &http.Client{

--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func run() int {
 		logWriter.Close()
 		return 5
 	}
-	mainLogger.Info("Endpoint: %s", endpoint)
+	mainLogger.Info("Endpoint: %s", endpoint.URL().String())
 	mainLogger.Info("Starting proxy server...")
 	handler := NewProxyHandler(endpoint, auth, resolver, proxyLogger)
 	mainLogger.Info("Init complete.")


### PR DESCRIPTION
Use IP addresses provided by Hola API to dial proxies w/o name resolving.