### PR TITLE
Bump hola api client version

### DIFF
--- a/holaapi.go
+++ b/holaapi.go
@@ -25,7 +25,7 @@ import (
 )
 
 const USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
-const EXT_VER = "1.186.562"
+const EXT_VER = "1.210.946"
 const EXT_BROWSER = "chrome"
 const PRODUCT = "cws"
 const CCGI_URL = "https://client.hola.org/client_cgi/"


### PR DESCRIPTION
zgettunnels no longer responds to old API version.